### PR TITLE
Album Detail, Home Page and FE Routes

### DIFF
--- a/albumclub/urls.py
+++ b/albumclub/urls.py
@@ -29,7 +29,7 @@ urlpatterns = [
 ]
 
 urlpatterns += [
-    re_path(r'.*', SpaView.as_view())  # Route non existent paths to svelte
+    re_path(r'.*', SpaView.as_view())  # Route non existent URLs to svelte
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/albumclub/urls.py
+++ b/albumclub/urls.py
@@ -14,10 +14,8 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path, include
-
+from django.urls import path, include, re_path
 from albumclub.spa.views import SpaView
-# from albumclub.api.views import GreetingApi
 from albumclub.api import views #this imports the views from views.py for the api app
 from rest_framework.urlpatterns import format_suffix_patterns
 
@@ -25,11 +23,13 @@ from rest_framework.urlpatterns import format_suffix_patterns
 urlpatterns = [
     path("admin/", admin.site.urls),
     path('accounts/', include('django.contrib.auth.urls')),
-    # path('api/greet', GreetingApi.as_view()),
-    path("", SpaView.as_view(), name="spa"),
     path('api/albums/', views.all_albums), #passing in the all_albums function 
     path('api/albums/<int:id>', views.album_detail), #adding parameter of type 'int' this will link up with album_detail function in view.py
+    path("", SpaView.as_view(), name="spa"),
+]
+
+urlpatterns += [
+    re_path(r'.*', SpaView.as_view())  # Route non existent paths to svelte
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)
-#

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "normalize.css": "^8.0.1",
-        "sirv-cli": "^2.0.0"
+        "sirv-cli": "^2.0.0",
+        "svelte-router-spa": "^6.0.3"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^17.0.0",
@@ -1050,9 +1051,19 @@
       "version": "3.55.1",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.55.1.tgz",
       "integrity": "sha512-S+87/P0Ve67HxKkEV23iCdAh/SX1xiSfjF1HOglno/YTbSTW7RniICMCofWGdJJbdjw3S+0PfFb1JtGfTXE0oQ==",
-      "dev": true,
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/svelte-router-spa": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svelte-router-spa/-/svelte-router-spa-6.0.3.tgz",
+      "integrity": "sha512-aHgyUVVI/WjipQNmKcXpX0hFZtkW5Y6hwH5aXLr2P/aRQ/qlX8ZbKQJUwKjOD59p7tt/c+wqokiIt68N7aNuKQ==",
+      "dependencies": {
+        "url-params-parser": "^1.0.3"
+      },
+      "peerDependencies": {
+        "svelte": "^3.36.0"
       }
     },
     "node_modules/terser": {
@@ -1100,6 +1111,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/url-params-parser": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/url-params-parser/-/url-params-parser-1.0.4.tgz",
+      "integrity": "sha512-0m6BqGpY2OetTZ3UPTLKkbTfUHigsX2YhrzORT9iYiyUJ/SP2WJ3cggg2YWtvMs36GPwK9Q44ffddyarniu2Tg=="
     },
     "node_modules/wrappy": {
       "version": "1.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
-    "start": "sirv public --no-clear"
+    "start": "sirv public -s --no-clear"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.0.0",
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "normalize.css": "^8.0.1",
-    "sirv-cli": "^2.0.0"
+    "sirv-cli": "^2.0.0",
+    "svelte-router-spa": "^6.0.3"
   }
 }

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,18 +1,11 @@
 <script>
-	import { onMount } from "svelte";
-	import Album from './components/organisms/Album.svelte';
 	import 'normalize.css';
-	import Comments from "./components/organisms/Comments.svelte";
-
-	export let name;
-
+    import {Router} from "svelte-router-spa";
+    import {routes} from "./routes";
 
 </script>
 
-<main>
-	<Album />
-	<Comments />
-</main>
+<Router {routes} />
 
 <style>
 	main {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -6,21 +6,12 @@
 
 	export let name;
 
-	let apiMessage = 'Waiting for server...';
 
-	onMount(async  () => {
-		let response = await fetch('api/greet')
-				.then((res) => res.json());
-		console.log(response);
-		apiMessage = JSON.stringify(response);
-	});
 </script>
 
 <main>
 	<Album />
 	<Comments />
-	<h3>Data from server API</h3>
-	{apiMessage}
 </main>
 
 <style>

--- a/frontend/src/components/organisms/Album.svelte
+++ b/frontend/src/components/organisms/Album.svelte
@@ -1,27 +1,18 @@
 <script>
     import AlbumHeader from "../molecules/Album/AlbumHeader.svelte";
     import AlbumInfo from "../molecules/Album/AlbumInfo.svelte";
-    import {onMount} from "svelte";
 
-	async function getAlbum() {
-		let response = await fetch('api/albums/1');
-        let data = await response.json();
-        console.log(data.albums);
-        return data.albums;
-	}
+    export let data;
 </script>
 
-{#await getAlbum()}
-	<p>...waiting</p>
-{:then data}
-	<div class="album-container">
-        <header>
-            <AlbumHeader
-                    title={data.title}
-                    artist={data.artist}
-                    genre={data.genre}
-            />
-        </header>
+<div class="album-container">
+    <header>
+        <AlbumHeader
+                title={data.title}
+                artist={data.artist}
+                genre={data.genre}
+        />
+    </header>
 
     <main>
         <AlbumInfo
@@ -36,10 +27,6 @@
 
     </footer>
 </div>
-{:catch error}
-	<p>An error occurred!</p>
-{/await}
-
 
 <style>
 

--- a/frontend/src/components/organisms/Album.svelte
+++ b/frontend/src/components/organisms/Album.svelte
@@ -1,32 +1,34 @@
 <script>
     import AlbumHeader from "../molecules/Album/AlbumHeader.svelte";
     import AlbumInfo from "../molecules/Album/AlbumInfo.svelte";
+    import {onMount} from "svelte";
 
-    // Hardcoded data for now. TODO: Implement loading data from json/API with defaults for missing data.
-    let album = {
-        "art": 'https://upload.wikimedia.org/wikipedia/en/f/f8/10000Days.jpg',
-        "title": '10000 Days',
-        "artist": 'Tool',
-        "genre": 'Progressive Metal/Rock',
-        "about": 'Overrated? Not at all! It\'s not my fault you can\'t pay attention to songs over 3 minutes long.'
-    }
+	async function getAlbum() {
+		let response = await fetch('api/albums/1');
+        let data = await response.json();
+        console.log(data.albums);
+        return data.albums;
+	}
 </script>
 
-<div class="album-container">
-    <header>
-        <AlbumHeader
-                title={album.title}
-                artist={album.artist}
-                genre={album.genre}
-        />
-    </header>
+{#await getAlbum()}
+	<p>...waiting</p>
+{:then data}
+	<div class="album-container">
+        <header>
+            <AlbumHeader
+                    title={data.title}
+                    artist={data.artist}
+                    genre={data.genre}
+            />
+        </header>
 
     <main>
         <AlbumInfo
-                title={album.title}
-                artist={album.artist}
-                imageUrl={album.art}
-                about={album.about}
+                title={data.title}
+                artist={data.artist}
+                imageUrl={data.artwork}
+                about={data.about}
         />
     </main>
 
@@ -34,6 +36,9 @@
 
     </footer>
 </div>
+{:catch error}
+	<p>An error occurred!</p>
+{/await}
 
 
 <style>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,10 +1,7 @@
 import App from './App.svelte';
 
 const app = new App({
-	target: document.body,
-	props: {
-		name: 'world'
-	}
+	target: document.body
 });
 
 export default app;

--- a/frontend/src/pages/AlbumPage.svelte
+++ b/frontend/src/pages/AlbumPage.svelte
@@ -3,7 +3,6 @@
 	import Comments from "../components/organisms/Comments.svelte";
 
 	export let currentRoute;
-	export let params;
 
 	async function getAlbum(id) {
         try {
@@ -14,6 +13,7 @@
             throw new Error('Album not found')
         }
 	}
+
 </script>
 
 <main>

--- a/frontend/src/pages/AlbumPage.svelte
+++ b/frontend/src/pages/AlbumPage.svelte
@@ -1,0 +1,38 @@
+<script>
+	import Album from '../components/organisms/Album.svelte';
+	import Comments from "../components/organisms/Comments.svelte";
+
+	export let currentRoute;
+	export let params;
+
+	async function getAlbum(id) {
+        try {
+            let response = await fetch(`/api/albums/${id}?format=json`);
+            let data = await response.json();
+            return data.albums;
+        } catch (e) {
+            throw new Error('Album not found')
+        }
+	}
+</script>
+
+<main>
+	{#await getAlbum(currentRoute.namedParams.id)}
+		<p>...waiting</p>
+	{:then data}
+		<Album {data}/>
+		<Comments />
+	{:catch error}
+		<p>Album not found!</p>
+	{/await}
+</main>
+
+<style>
+	main {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		margin: 0 auto;
+		font-family: "Bitstream Vera Sans Mono", Monaco, "Courier New", Courier, monospace;
+	}
+</style>

--- a/frontend/src/pages/HomePage.svelte
+++ b/frontend/src/pages/HomePage.svelte
@@ -1,0 +1,1 @@
+<h1>Album Club</h1>

--- a/frontend/src/pages/HomePage.svelte
+++ b/frontend/src/pages/HomePage.svelte
@@ -1,1 +1,32 @@
+<script>
+    import AlbumTitle from "../components/atoms/Album/AlbumTitle.svelte";
+    import AlbumArt from "../components/atoms/Album/AlbumArt.svelte";
+
+    export let params;
+    export let currentRoute;
+
+    async function getAlbums() {
+            try {
+                let response = await fetch('/api/albums/?format=json');
+                let data = await response.json();
+                return (data.albums);
+            } catch (e) {
+                throw new Error('No albums found')
+            }
+        }
+
+</script>
+
 <h1>Album Club</h1>
+{#await getAlbums()}
+		<p>...waiting</p>
+{:then albums}
+    {#each albums as album}
+        <a href={`/album/${album.id}`}>
+            <AlbumTitle title={album.title} artist={album.artist} />
+            <AlbumArt imageUrl={album.artwork} artist={album.artist} title={album.title}/>
+        </a>
+    {/each}
+{:catch error}
+		<p>No albums found!</p>
+{/await}

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -1,0 +1,19 @@
+import AlbumPage from "./pages/AlbumPage.svelte";
+import HomePage from "./pages/HomePage.svelte";
+const routes = [
+  {
+    name: '/',
+    component: HomePage
+  },
+  {
+    name: 'album/:id',
+    component: AlbumPage
+  },
+  {
+    name: '404',
+    path: '404',
+    component: HomePage
+  }
+];
+
+export {routes}


### PR DESCRIPTION
Done:
- Can look up single Album with `/album/{id}`. 
- List of all Albums at `/`.
- 404 redirects to HomePage for now. 
- Try/Catch blocks and error handling.
- Django now passes URLs that it doesn't know about to Svelte frontend.